### PR TITLE
update new key for 2.8 (kazuha memory and islandflash)

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -30,10 +30,10 @@ jobs:
           release_name="GICutscenes-$version-${{ matrix.arch }}"
 
           # Self contained
-          dotnet publish -c Release -r "${{ matrix.arch }}" -o "$release_name" --self-contained
+          dotnet publish -c Release -r "${{ matrix.arch }}" -o "$release_name_standalone" --self-contained
 
           # Framework dependant
-          dotnet publish -c Release -r $r --self-contained false -p:PublishTrimmed=false
+          dotnet publish -c Release -r "${{ matrix.arch }}" -o "$release_name" --self-contained false -p:PublishTrimmed=false
 
           if [ "${{ matrix.arch }}" == "win-x64" ]; then
             # Pack for standalone version

--- a/versions.json
+++ b/versions.json
@@ -60,19 +60,21 @@
                     "videos": ["Cs_MD_EQ400671001_KazuhaMemory"]
                 },
                 {
-                    "key": 0,
+                    "key": 3865005622692177,
                     "version": "40070",
-                    "videos": ["Cs_MD_EQ400701001_XinyanPlay"]
+                    "videos": [
+                        "Cs_MD_EQ400701001_XinyanPlay"
+                    ]
                 },
                 {
-                    "key": 0,
+                    "key": 2376853844266094,
                     "version": "40073",
                     "videos": [
                         "Cs_MD_EQ400731001_FischlFantasy"
                     ]
                 },
                 {
-                    "key": 0,
+                    "key": 2320676109514370,
                     "version": "40076",
                     "videos": [
                         "Cs_MD_EQ400761001_MonaDivination"

--- a/versions.json
+++ b/versions.json
@@ -49,6 +49,41 @@
                     "videos": ["Cs_LiYue_LQ110261501_YelanStory_Boy", "Cs_LiYue_LQ110261501_YelanStory_Girl"]
                 }
             ]
+        },
+        {
+            "encAudio": true,
+            "version": "2.8",
+            "videoGroups": [
+                {
+                    "key": 5623150388305012,
+                    "version": "40067",
+                    "videos": ["Cs_MD_EQ400671001_KazuhaMemory"]
+                },
+                {
+                    "key": 0,
+                    "version": "40070",
+                    "videos": ["Cs_MD_EQ400701001_XinyanPlay"]
+                },
+                {
+                    "key": 0,
+                    "version": "40073",
+                    "videos": [
+                        "Cs_MD_EQ400731001_FischlFantasy"
+                    ]
+                },
+                {
+                    "key": 0,
+                    "version": "40076",
+                    "videos": [
+                        "Cs_MD_EQ400761001_MonaDivination"
+                    ]
+                },
+                {
+                    "key": 2850973778349534,
+                    "version": "40065",
+                    "videos": ["Cs_MD_EQ400650301_IslandFlash_Boy", "Cs_MD_EQ400650301_IslandFlash_Girl"]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Well, follow the old way, the field is `Unk2700_KHDDIJNOICK` and it contains inside 2 packets `FinishedParentQuestNotify` and `FinishedParentQuestUpdateNotify`. 
I will try to update the other keys later. After I finished the quests (maybe late).