### PR TITLE
support hca decryption and optimize

### DIFF
--- a/src/FileTypes/USM.cs
+++ b/src/FileTypes/USM.cs
@@ -101,7 +101,7 @@ namespace GICutscenes.FileTypes
             }
         }
 
-        public Dictionary<string, List<string>> Demux(bool videoExtract, bool audioExtract, string outputDir)
+        public Dictionary<String, MemoryStream> Demux(bool videoExtract, bool audioExtract, string outputDir)
         {
 
             FileStream filePointer = File.OpenRead(_path);  // TODO: Use a binary reader
@@ -111,6 +111,7 @@ namespace GICutscenes.FileTypes
 
             Dictionary<string, BinaryWriter> fileStreams = new(); // File paths as keys
             Dictionary<string, List<string>> filePaths = new();
+            Dictionary<String, MemoryStream> hcaDataMap = new(); 
             string path;
             while (fileSize > 0)
             {
@@ -170,13 +171,8 @@ namespace GICutscenes.FileTypes
                                     // Might need some extra work if the audio has to be decrypted during the demuxing
                                     // (hello AudioMask)
                                     path = Path.Combine(outputDir, _filename[..^4] + $"_{info.chno}.hca");
-                                    if (!fileStreams.ContainsKey(path))
-                                    {
-                                        fileStreams.Add(path, new BinaryWriter(new FileStream(path, FileMode.Create, FileAccess.Write)));
-                                        if (!filePaths.ContainsKey("hca")) filePaths.Add("hca", new List<string> { path });
-                                        else filePaths["hca"].Add(path);
-                                    }
-                                    fileStreams[path].Write(data);
+                                    if (!hcaDataMap.ContainsKey(path)) { hcaDataMap.Add(path, new MemoryStream()); }
+                                    hcaDataMap[path].Write(data);
                                 }
                                 break;
                             default: // No need to implement it, we lazy
@@ -192,7 +188,7 @@ namespace GICutscenes.FileTypes
             // Closing Streams
             filePointer.Close();
             foreach (BinaryWriter stream in fileStreams.Values) stream.Close();
-            return filePaths;
+            return hcaDataMap;
         }
     }
 

--- a/src/GICutscenes.csproj
+++ b/src/GICutscenes.csproj
@@ -20,11 +20,13 @@
 	<RepositoryType>git</RepositoryType>
 	<AnalysisLevel>latest-all</AnalysisLevel>
 	<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	<ProduceReferenceAssembly>False</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <Optimize>False</Optimize>
     <DebugType>full</DebugType>
+    <FileAlignment>512</FileAlignment>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -32,6 +34,7 @@
 	<PublishSingleFile>true</PublishSingleFile>
 	<TieredCompilation>true</TieredCompilation>
 	<PublishReadyToRun>true</PublishReadyToRun>
+	<FileAlignment>512</FileAlignment>
 	<!--<RunAOTCompilation>true</RunAOTCompilation>-->
   </PropertyGroup>
 	

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -160,7 +160,7 @@ namespace GICutscenes
             Console.WriteLine($"Output folder : {outputArg}");
             byte[] key1Arg = Convert.FromHexString(key1 ?? "");
             byte[] key2Arg = Convert.FromHexString(key2 ?? "");
-            Demuxer.Demux(file.FullName, key1Arg, key2Arg, outputArg);
+            Demuxer.Demux(file.FullName, key1Arg, key2Arg, outputArg, engine);
             if (merge)
             {
                 MergeFiles(outputArg, Path.GetFileNameWithoutExtension(file.FullName), engine, subs);
@@ -177,7 +177,7 @@ namespace GICutscenes
             Console.WriteLine($"Output folder : {outputArg}");
             foreach (string f in Directory.EnumerateFiles(inputDir.FullName, "*.usm"))
             {
-                Demuxer.Demux(f, Array.Empty<byte>(), Array.Empty<byte>(), outputArg);
+                Demuxer.Demux(f, Array.Empty<byte>(), Array.Empty<byte>(), outputArg, engine);
                 if (!merge) continue;
 
                 MergeFiles(outputArg, Path.GetFileNameWithoutExtension(f), engine, subs);
@@ -216,6 +216,7 @@ namespace GICutscenes
         private static void MergeFiles(string outputPath, string basename, string engine, bool subs)
         {
             Merger merger;
+            String audioSuffix = ".wav";
             switch (engine)
             {
                 case "internal":
@@ -236,12 +237,13 @@ namespace GICutscenes
                         Path.GetFileNameWithoutExtension(settings.FfmpegPath) == "ffmpeg" ? settings.FfmpegPath : "") 
                         ? new FFMPEG(Path.Combine(outputPath, basename + ".mkv"), settings.FfmpegPath) : new FFMPEG(Path.Combine(outputPath, basename + ".mkv"));
                     merger.AddVideoTrack(Path.Combine(outputPath, basename + ".ivf"));
+                    audioSuffix = ".hca";  //ffmpeg decode decrypted hca files
                     break;
                 default:
                     throw new ArgumentException("Not implemented");
             }
             
-            foreach (string f in Directory.EnumerateFiles(outputPath, $"{basename}_*.wav"))
+            foreach (string f in Directory.EnumerateFiles(outputPath, $"{basename}_*{audioSuffix}"))
             {
                 if (!int.TryParse(Path.GetFileNameWithoutExtension(f)[^1..], out int language)) // Extracting language number from filename
                     throw new FormatException($"Unable to parse the language code from the file {Path.GetFileName(f)}.");

--- a/versions.json
+++ b/versions.json
@@ -1,107 +1,137 @@
 {
-    "list": [{
-            "key": 0,
-            "version": "common",
-            "videos": ["Ambor_Readings", "battlePass", "ChangeWeather", "Cs_102106_Summon_Boy", "Cs_102106_Summon_Girl", "Cs_102203_BeforeBattle_Boy", "Cs_102203_BeforeBattle_Girl", "Cs_102205_AfterBattle_Boy", "Cs_102205_AfterBattle_Girl", "Cs_4131904_HaiDaoChuXian_Boy", "Cs_4131904_HaiDaoChuXian_Girl", "Cs_Activity_4141307_Fenghuajie_Boy", "Cs_Activity_4141307_Fenghuajie_Girl", "Cs_EQAST4101101_ASTER_OP", "Cs_EQAST4111412_ASTER_Lenard", "Cs_EQHDJ005_HaiDengJie_Boy", "Cs_EQHDJ005_HaiDengJie_Girl", "Cs_GY11030_GYPersonal", "Cs_LYAQ107_NingGuang", "Cs_LYAQ1112308_LongWangStroy", "Cs_MDAQ018_MDCityShow", "Cs_MDAQ019_DragonInCity_Boy", "Cs_MDAQ019_DragonInCity_Girl", "Cs_MDAQ071_Davalin_Boy", "Cs_MDAQ071_Davalin_Girl", "Cs_WDLQ004_VentiLegends", "Cs_WQDY1800026_Memories", "Cs_XLQ1110104_XiaoPersonal", "MDAQ001_OPNew_Part1", "MDAQ001_OPNew_Part2_PlayerBoy", "MDAQ001_OPNew_Part2_PlayerGirl", "MDAQ041", "Cs_200211_WanYeXianVideo", "MDAQ063_ZhaiXingYaSideB_Boy", "MDAQ063_ZhaiXingYaSideB_Girl"]
-        }, {
-            "key": 1946182291478952,
-            "version": "2.0",
-            "videos": ["Cs_200803_ShougunBossPart1_Boy", "Cs_200803_ShougunBossPart1_Girl", "Cs_LQ12008_Ayaka_Boy", "Cs_LQ12008_Ayaka_Girl", "Cs_200806_ShougunBossPart2_Boy", "Cs_200806_ShougunBossPart2_Girl", "Cs_201104_DaoQiDengdao_P2_Boy", "Cs_201104_DaoQiDengdao_P2_Girl", "Cs_200919_SHG_Boy", "Cs_200919_SHG_Girl"]
-        }, {
-            "key": 8578639302762988,
-            "version": "2.1",
-            "videos": ["Cs_Inazuma_AQ202004_StatueDeprivedVision_Boy", "Cs_Inazuma_AQ202004_StatueDeprivedVision_Girl", "Cs_Inazuma_AQ202004_ResistanceCharge_Boy", "Cs_Inazuma_AQ202004_ResistanceCharge_Girl", "Cs_Inazuma_AQ202005_InazumaMucha", "Cs_LiYue_EQ4001515_Lunarite_Boy", "Cs_LiYue_EQ4001515_Lunarite_Girl", "Cs_Inazuma_AQ202006_InazumaEnding"]
-        }, {
-            "encAudio": true,
-            "key": 8986874010832568,
-            "version": "2.2",
-            "videos": ["Cs_Inazuma_EQ4002207_ShikishogunRecalling_Boy", "Cs_Inazuma_EQ4002207_ShikishogunRecalling_Girl"]
-        }, {
-            "encAudio": true,
-            "key": 4206600976229209,
-            "version": "2.3",
-            "videos": ["Cs_Inazuma_LQ1202615_IttoDungeonCrash_Girl", "Cs_Inazuma_LQ1202615_IttoDungeonCrash_Boy", "Cs_MD_EQ4002802_WinterCampAlbedoConfront", "Cs_Inazuma_LQ1200905_IttoOniStroy01", "Cs_Inazuma_LQ1202618_IttoOniStroy02", "Cs_MD_EQ4002810_WinterCampAlbedoBackstab_Boy", "Cs_MD_EQ4002810_WinterCampAlbedoBackstab_Girl"]
-        }, {
-            "encAudio": true,
-            "key": 7630808905721825,
-            "version": "2.4",
-            "videos": ["Cs_LQ1101502_ShenheBattle_Boy", "Cs_LQ1101502_ShenheBattle_Girl", "Cs_LiYue_EQ4003712_HdjFireworksShow_Boy", "Cs_LiYue_EQ4003712_HdjFireworksShow_Girl", "Cs_LQ1101505_YunjinOpera_Boy", "Cs_LQ1101505_YunjinOpera_Girl"]
-        }, {
-            "encAudio": true,
-            "key": 4614952043623735,
-            "version": "2.5",
-            "videos": ["Cs_Inazuma_EQ4005111_MichiaeMatsuri", "Cs_Inazuma_LQ1204205_IntoTheVoid_Boy", "Cs_Inazuma_LQ1204205_IntoTheVoid_Girl", "Cs_Inazuma_LQ1203105_YaeMiko_Girl", "Cs_Inazuma_LQ1204208_TheSacredTree_Boy", "Cs_Inazuma_LQ1204208_TheSacredTree_Girl", "Cs_Inazuma_LQ1203105_YaeMiko_Boy"]
-        }, {
-            "encAudio": true,
-            "key": 5578228838233776,
-            "version": "2.6",
-            "videos": ["Cs_ShieldingResources_02", "Cs_LiYue_AQ80070101_StopMechanismBig_Girl", "Cs_LiYue_AQ80070101_StopMechanismBig_Boy", "Cs_Inazuma_EQ400571101_IRODORI", "Cs_Inazuma_EQ400560901_IRODORI_Aoinookina", "Cs_Inazuma_EQ400551201_IRODORI_Suikou"]
-        }, {
-            "encAudio": true,
-            "version": "2.7",
-            "videoGroups": [{
-                    "key": 3303136414174011,
-                    "version": "1031",
-                    "videos": ["Cs_LiYue_LQ10310301_BreakThroughSpace_Boy", "Cs_LiYue_LQ10310301_BreakThroughSpace_Girl", "Cs_LiYue_LQ10310601_FusheStory"]
-                }, {
-                    "key": 6382832627668464,
-                    "version": "11026",
-                    "videos": ["Cs_LiYue_LQ110261501_YelanStory_Boy", "Cs_LiYue_LQ110261501_YelanStory_Girl"]
-                }
-            ]
-        },
-        {
-            "encAudio": true,
-            "version": "2.8",
-            "videoGroups": [
-                {
-                    "key": 5623150388305012,
-                    "version": "40067",
-                    "videos": ["Cs_MD_EQ400671001_KazuhaMemory"]
-                },
-                {
-                    "key": 3865005622692177,
-                    "version": "40070",
-                    "videos": [
-                        "Cs_MD_EQ400701001_XinyanPlay"
-                    ]
-                },
-                {
-                    "key": 2376853844266094,
-                    "version": "40073",
-                    "videos": [
-                        "Cs_MD_EQ400731001_FischlFantasy"
-                    ]
-                },
-                {
-                    "key": 2320676109514370,
-                    "version": "40076",
-                    "videos": [
-                        "Cs_MD_EQ400761001_MonaDivination"
-                    ]
-                },
-                {
-                    "key": 2850973778349534,
-                    "version": "40065",
-                    "videos": ["Cs_MD_EQ400650301_IslandFlash_Boy", "Cs_MD_EQ400650301_IslandFlash_Girl"]
-                }
-            ]
-        },
-        {
-          "encAudio": true, 
-          "version": "3.0",
-          "videoGroups": [
-            {
-              "key": 5515318060794455,
-              "version": "3006",
-              "videos": [ "Cs_Sumeru_AQ30061401_ALPlay_Boy", "Cs_Sumeru_AQ30061401_ALPlay_Girl" ]
-            },
-            {
-              "key": 2690561074476991,
-              "version": "3012",
-              "videos": [ "Cs_Sumeru_AQ30130101_DofFG_Girl", "Cs_Sumeru_AQ30130101_DofFG_Boy" ]
-            }
-          ]
-        }
-    ]
+	"list": [{
+			"key": 0,
+			"version": "common",
+			"videos": ["Ambor_Readings", "battlePass", "ChangeWeather", "Cs_102106_Summon_Boy", "Cs_102106_Summon_Girl", "Cs_102203_BeforeBattle_Boy", "Cs_102203_BeforeBattle_Girl", "Cs_102205_AfterBattle_Boy", "Cs_102205_AfterBattle_Girl", "Cs_4131904_HaiDaoChuXian_Boy", "Cs_4131904_HaiDaoChuXian_Girl", "Cs_Activity_4141307_Fenghuajie_Boy", "Cs_Activity_4141307_Fenghuajie_Girl", "Cs_EQAST4101101_ASTER_OP", "Cs_EQAST4111412_ASTER_Lenard", "Cs_EQHDJ005_HaiDengJie_Boy", "Cs_EQHDJ005_HaiDengJie_Girl", "Cs_GY11030_GYPersonal", "Cs_LYAQ107_NingGuang", "Cs_LYAQ1112308_LongWangStroy", "Cs_MDAQ018_MDCityShow", "Cs_MDAQ019_DragonInCity_Boy", "Cs_MDAQ019_DragonInCity_Girl", "Cs_MDAQ071_Davalin_Boy", "Cs_MDAQ071_Davalin_Girl", "Cs_WDLQ004_VentiLegends", "Cs_WQDY1800026_Memories", "Cs_XLQ1110104_XiaoPersonal", "MDAQ001_OPNew_Part1", "MDAQ001_OPNew_Part2_PlayerBoy", "MDAQ001_OPNew_Part2_PlayerGirl", "MDAQ041", "Cs_200211_WanYeXianVideo", "MDAQ063_ZhaiXingYaSideB_Boy", "MDAQ063_ZhaiXingYaSideB_Girl"]
+		}, {
+			"key": 1946182291478952,
+			"version": "2.0",
+			"videos": ["Cs_200803_ShougunBossPart1_Boy", "Cs_200803_ShougunBossPart1_Girl", "Cs_LQ12008_Ayaka_Boy", "Cs_LQ12008_Ayaka_Girl", "Cs_200806_ShougunBossPart2_Boy", "Cs_200806_ShougunBossPart2_Girl", "Cs_201104_DaoQiDengdao_P2_Boy", "Cs_201104_DaoQiDengdao_P2_Girl", "Cs_200919_SHG_Boy", "Cs_200919_SHG_Girl"]
+		}, {
+			"key": 8578639302762988,
+			"version": "2.1",
+			"videos": ["Cs_Inazuma_AQ202004_StatueDeprivedVision_Boy", "Cs_Inazuma_AQ202004_StatueDeprivedVision_Girl", "Cs_Inazuma_AQ202004_ResistanceCharge_Boy", "Cs_Inazuma_AQ202004_ResistanceCharge_Girl", "Cs_Inazuma_AQ202005_InazumaMucha", "Cs_LiYue_EQ4001515_Lunarite_Boy", "Cs_LiYue_EQ4001515_Lunarite_Girl", "Cs_Inazuma_AQ202006_InazumaEnding"]
+		}, {
+			"encAudio": true,
+			"key": 8986874010832568,
+			"version": "2.2",
+			"videos": ["Cs_Inazuma_EQ4002207_ShikishogunRecalling_Boy", "Cs_Inazuma_EQ4002207_ShikishogunRecalling_Girl"]
+		}, {
+			"encAudio": true,
+			"key": 4206600976229209,
+			"version": "2.3",
+			"videos": ["Cs_Inazuma_LQ1202615_IttoDungeonCrash_Girl", "Cs_Inazuma_LQ1202615_IttoDungeonCrash_Boy", "Cs_MD_EQ4002802_WinterCampAlbedoConfront", "Cs_Inazuma_LQ1200905_IttoOniStroy01", "Cs_Inazuma_LQ1202618_IttoOniStroy02", "Cs_MD_EQ4002810_WinterCampAlbedoBackstab_Boy", "Cs_MD_EQ4002810_WinterCampAlbedoBackstab_Girl"]
+		}, {
+			"encAudio": true,
+			"key": 7630808905721825,
+			"version": "2.4",
+			"videos": ["Cs_LQ1101502_ShenheBattle_Boy", "Cs_LQ1101502_ShenheBattle_Girl", "Cs_LiYue_EQ4003712_HdjFireworksShow_Boy", "Cs_LiYue_EQ4003712_HdjFireworksShow_Girl", "Cs_LQ1101505_YunjinOpera_Boy", "Cs_LQ1101505_YunjinOpera_Girl"]
+		}, {
+			"encAudio": true,
+			"key": 4614952043623735,
+			"version": "2.5",
+			"videos": ["Cs_Inazuma_EQ4005111_MichiaeMatsuri", "Cs_Inazuma_LQ1204205_IntoTheVoid_Boy", "Cs_Inazuma_LQ1204205_IntoTheVoid_Girl", "Cs_Inazuma_LQ1203105_YaeMiko_Girl", "Cs_Inazuma_LQ1204208_TheSacredTree_Boy", "Cs_Inazuma_LQ1204208_TheSacredTree_Girl", "Cs_Inazuma_LQ1203105_YaeMiko_Boy"]
+		}, {
+			"encAudio": true,
+			"key": 5578228838233776,
+			"version": "2.6",
+			"videos": ["Cs_ShieldingResources_02", "Cs_LiYue_AQ80070101_StopMechanismBig_Girl", "Cs_LiYue_AQ80070101_StopMechanismBig_Boy", "Cs_Inazuma_EQ400571101_IRODORI", "Cs_Inazuma_EQ400560901_IRODORI_Aoinookina", "Cs_Inazuma_EQ400551201_IRODORI_Suikou"]
+		}, {
+			"encAudio": true,
+			"version": "2.7",
+			"videoGroups": [{
+					"key": 3303136414174011,
+					"version": "1031",
+					"videos": ["Cs_LiYue_LQ10310301_BreakThroughSpace_Boy", "Cs_LiYue_LQ10310301_BreakThroughSpace_Girl", "Cs_LiYue_LQ10310601_FusheStory"]
+				}, {
+					"key": 6382832627668464,
+					"version": "11026",
+					"videos": ["Cs_LiYue_LQ110261501_YelanStory_Boy", "Cs_LiYue_LQ110261501_YelanStory_Girl"]
+				}
+			]
+		},
+		{
+			"encAudio": true,
+			"version": "2.8",
+			"videoGroups": [
+				{
+					"key": 5623150388305012,
+					"version": "40067",
+					"videos": ["Cs_MD_EQ400671001_KazuhaMemory"]
+				},
+				{
+					"key": 3865005622692177,
+					"version": "40070",
+					"videos": ["Cs_MD_EQ400701001_XinyanPlay"]
+				},
+				{
+					"key": 2376853844266094,
+					"version": "40073",
+					"videos": ["Cs_MD_EQ400731001_FischlFantasy"]
+				},
+				{
+					"key": 2320676109514370,
+					"version": "40076",
+					"videos": ["Cs_MD_EQ400761001_MonaDivination"]
+				},
+				{
+					"key": 2850973778349534,
+					"version": "40065",
+					"videos": ["Cs_MD_EQ400650301_IslandFlash_Boy", "Cs_MD_EQ400650301_IslandFlash_Girl"]
+				}
+			]
+		}, 
+		{
+			"encAudio": true,
+			"version": "3.0",
+			"videoGroups": [{
+					"key": 5515318060794455,
+					"version": "3006",
+					"videos": ["Cs_Sumeru_AQ30061401_ALPlay_Boy", "Cs_Sumeru_AQ30061401_ALPlay_Girl"]
+				}, {
+					"key": 2690561074476991,
+					"version": "3012",
+					"videos": ["Cs_Sumeru_AQ30130101_DofFG_Boy", "Cs_Sumeru_AQ30130101_DofFG_Girl"]
+				}
+			]
+		},
+		{
+			"encAudio": true,
+			"version": "3.1",
+			"videoGroups": [
+				{
+					"version": "3017",
+					"key": 6971018813708261,
+					"videos": ["Cs_Sumeru_AQ30170602_GF_Boy", "Cs_Sumeru_AQ30170602_GF_Girl", "Cs_Sumeru_AQ30170601_SOfS"]
+				},
+				{
+					"version": "13011",
+					"key": 7063052926021205,
+					"videos": ["Cs_Sumeru_LQ130111201_EnODeGa_Boy", "Cs_Sumeru_LQ130111201_EnODeGa_Girl"
+					]
+				},
+				{
+					"version": "3016",
+					"key": 8823377679488754,
+					"videos": ["Cs_Sumeru_AQ30161501_DT_Boy", "Cs_Sumeru_AQ30161501_DT_Girl"
+					]
+				},
+				{
+					"version": "3021",
+					"key": 7828263898924570,
+					"videos": ["Cs_Sumeru_AQ302103_FOTD_Boy", "Cs_Sumeru_AQ302103_FOTD_Girl", "Cs_Sumeru_AQ302105_GOTP"]
+				},
+				{
+					"version": "40080",
+					"key": 0,
+					"videos": ["Cs_MD_EQ400800601_VinFes_Boy", "Cs_MD_EQ400800601_VinFes_Girl"]
+				},
+				{
+					"version": "3020",
+					"key": 3668457735028873,
+					"videos": ["Cs_Sumeru_AQ302009_MOTM"]
+				}
+			]
+		}
+	]
 }


### PR DESCRIPTION
cache decrypted hca data in memory to decrease disk io and increased speed by 15% to 35% (test on my computer).
set "-e ffmpeg" to enable decrypted hca export, because ffmpeg support hca decode.