### PR TITLE
Some improvement in performance and reliability

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -2,6 +2,7 @@
   "Settings": {
     "MkvMergePath": "",
     "FfmpegPath": "",
-    "SubsFolder": "./GenshinData/Subtitle"
+    "SubsFolder": "./GenshinData/Subtitle",
+    "SubtiteStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -3,6 +3,6 @@
     "MkvMergePath": "",
     "FfmpegPath": "",
     "SubsFolder": "./GenshinData/Subtitle",
-    "SubtiteStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
+    "SubsStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
   }
 }

--- a/src/Demuxer.cs
+++ b/src/Demuxer.cs
@@ -45,9 +45,10 @@ namespace GICutscenes
 
         private static (ulong, bool) EncryptionKeyInBLK(string videoFilename)
         {
-            if (!File.Exists("versions.json")) throw new FileNotFoundException("File versions.json couldn't be found in the folder of the tool.");
+            var versionsFilePath = Path.Combine(AppContext.BaseDirectory, "versions.json");
+            if (!File.Exists(versionsFilePath)) throw new FileNotFoundException("File versions.json couldn't be found in the folder of the tool.");
             videoFilename = Path.GetFileNameWithoutExtension(videoFilename);
-            string jsonString = File.ReadAllText("versions.json");
+            string jsonString = File.ReadAllText(versionsFilePath);
             VersionList? versions = JsonSerializer.Deserialize<VersionList>(jsonString, VersionJson.Default.VersionList);
             if (versions?.list == null) throw new JsonException("Json content from versions.json is invalid or couldn't be parsed...");
             Version? v = Array.Find(versions.list, x => (x.videos != null && x.videos.Contains(videoFilename)) || (x.videoGroups != null && Array.Exists(x.videoGroups, y => y.videos != null && y.videos.Contains(videoFilename))));
@@ -56,7 +57,7 @@ namespace GICutscenes
             if (v.videoGroups != null)
             {
                 key = Array.Find(v.videoGroups, y => y.videos != null && y.videos.Contains(videoFilename))?.key ?? throw new KeyNotFoundException("Unable to find the second key in versions.json for " + videoFilename);
-            } 
+            }
             return (key, v.encAudio ?? false);
         }
 

--- a/src/FileTypes/ASS.cs
+++ b/src/FileTypes/ASS.cs
@@ -80,7 +80,7 @@ PlayDepth: 0
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,{_fontname},18,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,20,1
+Style: Default,{_fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1
 
 [Events]
 Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text" + Environment.NewLine;

--- a/src/FileTypes/ASS.cs
+++ b/src/FileTypes/ASS.cs
@@ -82,13 +82,13 @@ namespace GICutscenes.FileTypes
                 [V4+ Styles]
                 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
                 """);
-            if (string.IsNullOrWhiteSpace(Program.settings?.SubtiteStyle))
+            if (string.IsNullOrWhiteSpace(Program.settings?.SubsStyle))
             {
                 sb.AppendLine($"Style: Default,{_fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1");
             }
             else
             {
-                sb.AppendLine(Program.settings?.SubtiteStyle.Replace("{fontname}", _fontname));
+                sb.AppendLine(Program.settings?.SubsStyle.Replace("{fontname}", _fontname));
             }
             sb.AppendLine("""
                 

--- a/src/GICutscenes.csproj
+++ b/src/GICutscenes.csproj
@@ -1,46 +1,47 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Version>0.4.1</Version>
-	<OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-	  <!--<RuntimeIdentifier>win-x64</RuntimeIdentifier>-->
-	<PublishTrimmed>true</PublishTrimmed>
-	<Authors>ToaHartor</Authors>
-    <RootNamespace>GICutscenes</RootNamespace>
-	<Description>A command line program playing with the cutscenes files (USM) from Genshin Impact.</Description>
-	<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-	<RepositoryUrl>https://github.com/ToaHartor/GI-cutscenes</RepositoryUrl>
+	<PropertyGroup>
+		<Version>0.4.1</Version>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<!--<RuntimeIdentifier>win-x64</RuntimeIdentifier>-->
+		<PublishTrimmed>true</PublishTrimmed>
+		<Authors>ToaHartor</Authors>
+		<RootNamespace>GICutscenes</RootNamespace>
+		<Description>A command line program playing with the cutscenes files (USM) from Genshin Impact.</Description>
+		<PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/ToaHartor/GI-cutscenes</RepositoryUrl>
 
-	<Nullable>enable</Nullable>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-	<DebugType>embedded</DebugType>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<RepositoryType>git</RepositoryType>
-	<AnalysisLevel>latest-all</AnalysisLevel>
-	<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-  </PropertyGroup>
+		<Nullable>enable</Nullable>
+		<LangVersion>preview</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+		<DebugType>embedded</DebugType>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryType>git</RepositoryType>
+		<AnalysisLevel>latest-all</AnalysisLevel>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <Optimize>False</Optimize>
-    <DebugType>full</DebugType>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<Optimize>False</Optimize>
+		<DebugType>full</DebugType>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>full</DebugType>
-	<PublishSingleFile>true</PublishSingleFile>
-	<TieredCompilation>true</TieredCompilation>
-	<PublishReadyToRun>true</PublishReadyToRun>
-	<!--<RunAOTCompilation>true</RunAOTCompilation>-->
-  </PropertyGroup>
-	
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-preview.5.22301.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0-preview.5.22301.12" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0-preview.5.22301.12" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>full</DebugType>
+		<PublishSingleFile>true</PublishSingleFile>
+		<TieredCompilation>true</TieredCompilation>
+		<PublishReadyToRun>true</PublishReadyToRun>
+		<!--<RunAOTCompilation>true</RunAOTCompilation>-->
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0-preview.5.22301.12" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0-preview.5.22301.12" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0-preview.5.22301.12" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<Content Include="../appsettings.json">
@@ -55,10 +56,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Include="..\.editorconfig" Link=".editorconfig" />
-	  <None Include="..\README.md">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+		<None Include="..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
 	</ItemGroup>
 </Project>

--- a/src/Mergers/FFMPEG.cs
+++ b/src/Mergers/FFMPEG.cs
@@ -107,5 +107,14 @@ namespace GICutscenes.Mergers
             Process process = Process.Start(_ffmpeg, _command);
             process.WaitForExit();
         }
+
+        public void Merge(string audioFormat, string videoFormat)
+        {
+            _command += string.Join(" ", _inputOptions) + string.Join(" ", _mapOptions) + string.Join(" ", _metadataOptions);
+            _command += $" -c:a \"{(string.IsNullOrWhiteSpace(audioFormat) ? "copy" : audioFormat)}\" -c:v \"{(string.IsNullOrWhiteSpace(videoFormat) ? "copy" : videoFormat)}\" \"{_output}\"";
+            //Console.WriteLine(_ffmpeg + _command);
+            Process process = Process.Start(_ffmpeg, _command);
+            process.WaitForExit();
+        }
     }
 }

--- a/src/Mergers/Merger.cs
+++ b/src/Mergers/Merger.cs
@@ -13,5 +13,7 @@
 
         void Merge();
 
+        void Merge(string audioFormat, string videoFormat) { }
+
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -129,10 +129,10 @@ namespace GICutscenes
 
             // Command Handlers
             demuxUsmCommand.SetHandler(async (FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup) =>
-                {
+            {
                 ReadSetting();
-                    await DemuxUsmCommand(file, key1, key2, output, engine, merge, subs, noCleanup);
-                }, demuxFileOption, key1Option, key2Option, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
+                await DemuxUsmCommand(file, key1, key2, output, engine, merge, subs, noCleanup);
+            }, demuxFileOption, key1Option, key2Option, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
 
             batchDemuxCommand.SetHandler(async (DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup) =>
@@ -181,13 +181,13 @@ namespace GICutscenes
 
         private static async Task DemuxUsmCommand(FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup)
         {
-            if (file == null) throw new ArgumentNullException("No file provided.");
+            if (file == null) throw new ArgumentNullException(nameof(file), "No file provided.");
             if (!file.Exists) throw new ArgumentException("File {0} does not exist.", file.Name);
             if (!file.Name.EndsWith(".usm"))
                 throw new ArgumentException($"File {file.Name} provided isn't a .usm file.");
             if (key1 != null && key2 != null && (key1.Length != 8 || key2.Length != 8)) throw new ArgumentException("Keys are invalid.");
             string outputArg = output == null
-                ? file.Directory.FullName
+                ? file.Directory!.FullName
                 : ((output.Exists) ? output.FullName : throw new ArgumentException("Output directory is invalid."));
             Console.WriteLine($"Output folder : {outputArg}");
             byte[] key1Arg = Convert.FromHexString(key1 ?? "");
@@ -258,15 +258,15 @@ namespace GICutscenes
                 case "mkvmerge":
                     Console.WriteLine("Merging using mkvmerge.");
                     merger = File.Exists(
-                            Path.GetFileNameWithoutExtension(settings.MkvMergePath) == "mkvmerge" ? settings.MkvMergePath : "")
-                        ? new Mkvmerge(Path.Combine(outputPath, basename + ".mkv"), settings.MkvMergePath) : new Mkvmerge(Path.Combine(outputPath, basename + ".mkv"));
+                        Path.GetFileNameWithoutExtension(settings?.MkvMergePath)?.ToLower() == "mkvmerge" ? settings?.MkvMergePath : "")
+                        ? new Mkvmerge(Path.Combine(outputPath, basename + ".mkv"), settings!.MkvMergePath!) : new Mkvmerge(Path.Combine(outputPath, basename + ".mkv"));
                     merger.AddVideoTrack(Path.Combine(outputPath, basename + ".ivf"));
                     break;
                 case "ffmpeg":
                     Console.WriteLine("Merging using ffmpeg.");
                     merger = File.Exists(
-                        Path.GetFileNameWithoutExtension(settings.FfmpegPath) == "ffmpeg" ? settings.FfmpegPath : "")
-                        ? new FFMPEG(Path.Combine(outputPath, basename + ".mkv"), settings.FfmpegPath) : new FFMPEG(Path.Combine(outputPath, basename + ".mkv"));
+                        Path.GetFileNameWithoutExtension(settings?.FfmpegPath)?.ToLower() == "ffmpeg" ? settings?.FfmpegPath : "")
+                        ? new FFMPEG(Path.Combine(outputPath, basename + ".mkv"), settings!.FfmpegPath!) : new FFMPEG(Path.Combine(outputPath, basename + ".mkv"));
                     merger.AddVideoTrack(Path.Combine(outputPath, basename + ".ivf"));
                     break;
                 default:
@@ -282,7 +282,7 @@ namespace GICutscenes
 
             if (subs)
             {
-                string subsFolder = settings.SubsFolder ?? throw new ArgumentException("Configuration value is not set for the key SubsFolder.");
+                string subsFolder = settings?.SubsFolder ?? throw new ArgumentException("Configuration value is not set for the key SubsFolder.");
                 subsFolder = Path.GetFullPath(subsFolder);
                 if (!Directory.Exists(subsFolder))
                     throw new ArgumentException(

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -84,8 +84,6 @@ namespace GICutscenes
             rootCommand.AddGlobalOption(outputFolderOption);
             rootCommand.AddGlobalOption(noCleanupOption);
 
-            var resetCommand = new Command("reset", "Reset 'appsettings.json' file to default.");
-
             var demuxUsmCommand = new Command("demuxUsm", "Demuxes a specified .usm file to a specified folder")
             {
                 demuxFileOption,
@@ -111,20 +109,12 @@ namespace GICutscenes
                 hcaInputArg
             };
 
-            rootCommand.AddCommand(resetCommand);
+            var resetCommand = new Command("reset", "Reset 'appsettings.json' file to default.");
+
             rootCommand.AddCommand(demuxUsmCommand);
             rootCommand.AddCommand(batchDemuxCommand);
             rootCommand.AddCommand(convertHcaCommand);
-
-            resetCommand.SetHandler(() =>
-            {
-                var obj = new { Settings = new Settings { FfmpegPath = "", MkvMergePath = "", SubsFolder = "" } };
-                var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), json);
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("'appsettings.json' has reset to default.");
-                Console.ResetColor();
-            });
+            rootCommand.AddCommand(resetCommand);
 
 
             // Command Handlers
@@ -142,14 +132,22 @@ namespace GICutscenes
                 await BatchDemuxCommand(inputDir, outputDir, engine, merge, subs, noCleanup);
                 timer.Stop();
                 Console.WriteLine($"{timer.ElapsedMilliseconds}ms elapsed");
-            },
-                usmFolderArg, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
+            }, usmFolderArg, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
             convertHcaCommand.SetHandler(async (FileSystemInfo input, DirectoryInfo? output, bool noCleanup) =>
             {
                 await ConvertHcaCommand(input, output /*, noCleanup*/);
-            },
-                hcaInputArg, outputFolderOption, noCleanupOption);
+            }, hcaInputArg, outputFolderOption, noCleanupOption);
+
+            resetCommand.SetHandler(() =>
+            {
+                var obj = new { Settings = new Settings { FfmpegPath = "", MkvMergePath = "", SubsFolder = "" } };
+                var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), json);
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("'appsettings.json' has reset to default.");
+                Console.ResetColor();
+            });
 
             return Task.FromResult(rootCommand.InvokeAsync(args).Result);
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,7 +18,7 @@ namespace GICutscenes
         public string? MkvMergePath { get; set; }
         public string? SubsFolder { get; set; }
         public string? FfmpegPath { get; set; }
-        public string? SubtiteStyle { get; set; }
+        public string? SubsStyle { get; set; }
 
     }
     internal sealed class Program
@@ -203,7 +203,7 @@ namespace GICutscenes
                     "MkvMergePath": "",
                     "FfmpegPath": "",
                     "SubsFolder": "",
-                    "SubtiteStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
+                    "SubsStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
                   }
                 }
                 """;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -126,25 +126,25 @@ namespace GICutscenes
 
 
             // Command Handlers
-            demuxUsmCommand.SetHandler(async (FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup) =>
+            demuxUsmCommand.SetHandler((FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup) =>
             {
                 ReadSetting();
-                await DemuxUsmCommand(file, key1, key2, output, engine, merge, subs, noCleanup);
+                DemuxUsmCommand(file, key1, key2, output, engine, merge, subs, noCleanup);
             }, demuxFileOption, key1Option, key2Option, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
 
-            batchDemuxCommand.SetHandler(async (DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup) =>
+            batchDemuxCommand.SetHandler((DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup) =>
             {
                 ReadSetting();
                 var timer = System.Diagnostics.Stopwatch.StartNew();
-                await BatchDemuxCommand(inputDir, outputDir, engine, merge, subs, noCleanup);
+                BatchDemuxCommand(inputDir, outputDir, engine, merge, subs, noCleanup);
                 timer.Stop();
                 Console.WriteLine($"{timer.ElapsedMilliseconds}ms elapsed");
             }, usmFolderArg, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
-            convertHcaCommand.SetHandler(async (FileSystemInfo input, DirectoryInfo? output, bool noCleanup) =>
+            convertHcaCommand.SetHandler((FileSystemInfo input, DirectoryInfo? output, bool noCleanup) =>
             {
-                await ConvertHcaCommand(input, output /*, noCleanup*/);
+                ConvertHcaCommand(input, output /*, noCleanup*/);
             }, hcaInputArg, outputFolderOption, noCleanupOption);
 
             resetCommand.SetHandler(() =>
@@ -197,7 +197,7 @@ namespace GICutscenes
         }
 
 
-        private static async Task DemuxUsmCommand(FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup)
+        private static void DemuxUsmCommand(FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup)
         {
             if (file == null) throw new ArgumentNullException(nameof(file), "No file provided.");
             if (!file.Exists) throw new ArgumentException("File {0} does not exist.", file.Name);
@@ -218,7 +218,7 @@ namespace GICutscenes
             }
         }
 
-        private static async Task BatchDemuxCommand(DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup)
+        private static void BatchDemuxCommand(DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup)
         {
             if (inputDir is not { Exists: true }) throw new DirectoryNotFoundException("Input directory is invalid.");
             string outputArg = (outputDir == null)
@@ -235,7 +235,7 @@ namespace GICutscenes
             }
         }
 
-        private static async Task ConvertHcaCommand(FileSystemInfo input, DirectoryInfo? output)
+        private static void ConvertHcaCommand(FileSystemInfo input, DirectoryInfo? output)
         {
             if (!input.Exists) throw new ArgumentException("No file or directory given.");
             string outputArg = (output == null)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -84,18 +84,20 @@ namespace GICutscenes
             mkvEngineOption.AddAlias("-e");
 
             var notOpenBrowserOption = new Option<bool>(
-                name: "-n",
+                name: "--no-browser",
                 description: "Do not open browser if there's new version.");
+            notOpenBrowserOption.AddAlias("-nb");
+
+            var proxyOption = new Option<string>(
+               name: "--proxy",
+               description: "Specifies a proxy server for the request.");
+            proxyOption.AddAlias("-p");
 
             var stackTraceOption = new Option<bool>(
                 name: "--stack-trace",
                 description: "Show stack trace when throw exception.");
             stackTraceOption.AddAlias("-st");
 
-            var proxyOption = new Option<string>(
-                name: "--proxy",
-                description: "Specifies a proxy server for the request.");
-            proxyOption.AddAlias("-p");
 
 
             var rootCommand = new RootCommand("A command line program playing with the cutscenes files (USM) from Genshin Impact.");
@@ -416,6 +418,7 @@ namespace GICutscenes
 
                     Console.ForegroundColor = ConsoleColor.DarkYellow;
                     Console.WriteLine($"Latest version is '{release?.TagName}', GICutscenes needs to update.");
+                    Console.WriteLine($"Release page: {release?.HtmlUrl}");
                     Console.ResetColor();
                     if (!notOpenBroswer)
                     {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,6 +18,7 @@ namespace GICutscenes
         public string? MkvMergePath { get; set; }
         public string? SubsFolder { get; set; }
         public string? FfmpegPath { get; set; }
+        public string? SubtiteStyle { get; set; }
 
     }
     internal sealed class Program
@@ -182,9 +183,17 @@ namespace GICutscenes
 
             resetCommand.SetHandler(() =>
             {
-                var obj = new { Settings = new Settings { FfmpegPath = "", MkvMergePath = "", SubsFolder = "" } };
-                var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), json);
+                const string str = """
+                {
+                  "Settings": {
+                    "MkvMergePath": "",
+                    "FfmpegPath": "",
+                    "SubsFolder": "",
+                    "SubtiteStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
+                  }
+                }
+                """;
+                File.WriteAllText(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), str);
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("'appsettings.json' has reset to default.");
                 Console.ResetColor();
@@ -249,6 +258,10 @@ namespace GICutscenes
                 MergeFiles(outputArg, Path.GetFileNameWithoutExtension(file.FullName), engine, subs);
                 if (!noCleanup) CleanFiles(outputArg, Path.GetFileNameWithoutExtension(file.FullName));
             }
+            if (!noCleanup && Directory.Exists(Path.Combine(outputArg, "Subs")))
+            {
+                Directory.Delete(Path.Combine(outputArg, "Subs"), true);
+            }
         }
 
         private static void BatchDemuxCommand(DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup)
@@ -265,6 +278,10 @@ namespace GICutscenes
 
                 MergeFiles(outputArg, Path.GetFileNameWithoutExtension(f), engine, subs);
                 if (!noCleanup) CleanFiles(outputArg, Path.GetFileNameWithoutExtension(f));
+            }
+            if (!noCleanup && Directory.Exists(Path.Combine(outputArg, "Subs")))
+            {
+                Directory.Delete(Path.Combine(outputArg, "Subs"), true);
             }
         }
 
@@ -367,7 +384,7 @@ namespace GICutscenes
                                 if (!sub.IsAss())
                                 {
                                     sub.ParseSrt();
-                                    subFile = sub.ConvertToAss();
+                                    subFile = sub.ConvertToAss(outputPath);
                                 }
 
                                 merger.AddSubtitlesTrack(subFile, lang);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -407,7 +407,7 @@ namespace GICutscenes
             Console.ForegroundColor = ConsoleColor.DarkGray;
             Console.WriteLine("Update 'versions.json'...");
             Console.ResetColor();
-            var versionsString = await client.GetStringAsync("https://raw.githubusercontent.com/ToaHartor/GI-cutscenes/main/versions.json");
+            var versionsString = await client.GetStringAsync("https://cdn.jsdelivr.net/gh/ToaHartor/GI-cutscenes@main/versions.json");
             await File.WriteAllTextAsync(Path.Combine(AppContext.BaseDirectory, "versions.json"), versionsString);
             Console.WriteLine("'versions.json' has updated to the latest version.");
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -43,7 +43,7 @@ namespace GICutscenes
 
             var outputFolderOption = new Option<DirectoryInfo?>(
                 name: "--output",
-                description: "Output folder."
+                description: "Output folder, default is './output'."
                 );
             outputFolderOption.AddAlias("-o");
 
@@ -151,6 +151,8 @@ namespace GICutscenes
             demuxUsmCommand.SetHandler((FileInfo file, string key1, string key2, DirectoryInfo? output, string engine, bool merge, bool subs, bool noCleanup) =>
             {
                 ReadSetting();
+                output ??= new DirectoryInfo("./output");
+                output.Create();
                 DemuxUsmCommand(file, key1, key2, output, engine, merge, subs, noCleanup);
             }, demuxFileOption, key1Option, key2Option, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
@@ -158,16 +160,20 @@ namespace GICutscenes
             batchDemuxCommand.SetHandler((DirectoryInfo inputDir, DirectoryInfo? outputDir, string engine, bool merge, bool subs, bool noCleanup) =>
             {
                 ReadSetting();
+                outputDir ??= new DirectoryInfo("./output");
+                outputDir.Create();
                 var timer = Stopwatch.StartNew();
                 BatchDemuxCommand(inputDir, outputDir, engine, merge, subs, noCleanup);
                 timer.Stop();
                 Console.WriteLine($"{timer.ElapsedMilliseconds}ms elapsed");
             }, usmFolderArg, outputFolderOption, mkvEngineOption, mergeOption, subsOption, noCleanupOption);
 
-            convertHcaCommand.SetHandler((FileSystemInfo input, DirectoryInfo? output, bool noCleanup) =>
+            convertHcaCommand.SetHandler((FileSystemInfo input, DirectoryInfo? output) =>
             {
-                ConvertHcaCommand(input, output /*, noCleanup*/);
-            }, hcaInputArg, outputFolderOption, noCleanupOption);
+                output ??= new DirectoryInfo("./output");
+                output.Create();
+                ConvertHcaCommand(input, output);
+            }, hcaInputArg, outputFolderOption);
 
             updateCommand.SetHandler(async (bool notOpenBrowser, string proxy) =>
             {

--- a/src/Utils/GithubRelease.cs
+++ b/src/Utils/GithubRelease.cs
@@ -1,0 +1,100 @@
+﻿using System.Text.Json.Serialization;
+
+namespace GICutscenes.Utils;
+
+internal class GithubRelease
+{
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+
+    [JsonPropertyName("assets_url")]
+    public string AssetsUrl { get; set; }
+
+    [JsonPropertyName("upload_url")]
+    public string UploadUrl { get; set; }
+
+    [JsonPropertyName("html_url")]
+    public string HtmlUrl { get; set; }
+
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("node_id")]
+    public string NodeId { get; set; }
+
+    [JsonPropertyName("tag_name")]
+    public string TagName { get; set; }
+
+    [JsonPropertyName("target_commitish")]
+    public string TargetCommitish { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("draft")]
+    public bool Draft { get; set; }
+
+    [JsonPropertyName("prerelease")]
+    public bool Prerelease { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("published_at")]
+    public DateTime PublishedAt { get; set; }
+
+    [JsonPropertyName("assets")]
+    public List<GithubAsset> Assets { get; set; }
+
+    [JsonPropertyName("tarball_url")]
+    public string TarballUrl { get; set; }
+
+    [JsonPropertyName("zipball_url")]
+    public string ZipballUrl { get; set; }
+
+    [JsonPropertyName("body")]
+    public string Body { get; set; }
+
+}
+
+
+public class GithubAsset
+{
+    [JsonPropertyName("url")]
+    public string Url { get; set; }
+
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("node_id")]
+    public string NodeId { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; }
+
+    [JsonPropertyName("content_type")]
+    public string ContentType { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; }
+
+    [JsonPropertyName("size")]
+    public int Size { get; set; }
+
+    [JsonPropertyName("download_count")]
+    public int DownloadCount { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public DateTime UpdatedAt { get; set; }
+
+    [JsonPropertyName("browser_download_url")]
+    public string BrowserDownloadUrl { get; set; }
+}
+

--- a/src/Utils/Utils.cs
+++ b/src/Utils/Utils.cs
@@ -1,114 +1,38 @@
 ﻿
+using System.Net;
+
 namespace GICutscenes.Utils
 {
     internal class Tools
     {
         public static ushort Bswap(ushort v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            ushort r = (ushort)(v & 0xFF);
-            r <<= 8;
-            v >>= 8;
-            r |= (ushort)(v & 0xFF);
-            return r;
+            return (ushort)IPAddress.HostToNetworkOrder((short)v);
         }
 
         public static short Bswap(short v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            short r = (short)(v & 0xFF);
-            r <<= 8;
-            v >>= 8;
-            r |= (short)(v & 0xFF);
-            return r;
+            return IPAddress.HostToNetworkOrder(v);
         }
 
         public static int Bswap(int v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            int r = v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            return r;
+            return IPAddress.HostToNetworkOrder(v);
         }
 
         public static uint Bswap(uint v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            uint r = v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            return r;
+            return (uint)IPAddress.HostToNetworkOrder((int)v);
         }
 
         public static long Bswap(long v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            long r = v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            return r;
+            return IPAddress.HostToNetworkOrder(v);
         }
 
         public static ulong Bswap(ulong v)
         {
-            if (!BitConverter.IsLittleEndian) return v;
-            ulong r = v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            r <<= 8;
-            v >>= 8;
-            r |= v & 0xFF;
-            return r;
+            return (ulong)IPAddress.HostToNetworkOrder((long)v);
         }
 
         public static float Bswap(float v)
@@ -117,6 +41,7 @@ namespace GICutscenes.Utils
             uint i = Bswap(BitConverter.SingleToUInt32Bits(v));
             return BitConverter.UInt32BitsToSingle(i);
         }
+
         public static uint Ceil2(uint a, uint b) { return (uint)(b > 0 ? a / b + (a % b != 0 ? 1 : 0) : 0); }
     }
 }


### PR DESCRIPTION
## Improve endian convert method

Use `IPAddress.HostToNetworkOrder` insead.

``` cs
[Benchmark]
public void BSwap()
{
    Tools.Bswap(1946182291478952);
}

[Benchmark(Baseline = true)]
public void IpSwap()
{
    IPAddress.HostToNetworkOrder(1946182291478952);
}
```
<img width="542" alt="image" src="https://user-images.githubusercontent.com/61003590/198036015-c1d46410-b678-4b1b-9a87-8926ee58e15c.png">

## Use absolute path

Imagine that when open terminal from other directory not contains `GICutscenes.exe`, the program cannot find file `appsettings.json` and `versions.json`. Use absolute path to solve this problem.

## Add command to reset appsettings.json

If `appsettings.json` is accidentally damaged or changed section name, program throw exception at the first time. So I made some changes:

- Add command to reset file `appsettings.json` to default `GICutsences.exe reset`
- Move read setting method to the beginning of command handler

## Handle Exception

Showing stack trace when throw exception is unnecessary, and it occupies a large space in the terminal. I added an option and exception handler to define whether shows it.

```
Options:
  -st, --stack-trace     Show stack trace when throw exception.
```

Comparison:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/61003590/198168491-57f30558-23c1-49fa-80a2-1bfa0b110282.png">
<img width="914" alt="image" src="https://user-images.githubusercontent.com/61003590/198168593-00575017-f31e-47a8-971b-0623d1c77c93.png">

## Update Command

#28 

Use `GICutscenes.exe update` to download `versions.json` and check update for program. Comparing program's `AssemblyVerison` and tag name of the latest release, skip the first character of tag name.

Critical code:
``` cs
var currentVersion = typeof(Program).Assembly.GetName().Version;
// skip first character
if (System.Version.TryParse(release?.TagName?[1..], out var latestVersion))
{
    if (latestVersion > currentVersion)
    {
        // need to update, open browser to release page
    }
    else
    {
        // is already the latest version
    }
}
else
{
    // cannot compare verision
}
```

And there are two options of update command:

- `-nb`, do not open bowser if there's new version
- `-p`, specifies a proxy server for the request

## Support Encoding Format when Merge into mkv

#55 

## Custom Subtutles Style

#41 

Add `SubsStyle` node to appSettings.json, default is 
```
Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1
```

The converted ass subs will be saved in `{outputPath}/Subs/` and deleted after task if no `--no-cleanup`.