### PR TITLE
Ass subtitels in WinUI media player

### DIFF
--- a/src/FileTypes/ASS.cs
+++ b/src/FileTypes/ASS.cs
@@ -78,6 +78,8 @@ namespace GICutscenes.FileTypes
                 Collisions: Normal
                 ScaledBorderAndShadow: yes
                 PlayDepth: 0
+                PlayResX: 384
+                PlayResY: 288
                 
                 [V4+ Styles]
                 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding


### PR DESCRIPTION
After adding these two lines, the WinUI media player can display subtitles.