### PR TITLE
Audio language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Several options are available for most of the commands :
 - `--no-cleanup` disables the suppression of the extracted files after merging
 - `--mkv-engine` specifies the merging program used (either `internal`, `mkvmerge` or `ffmpeg`, using the internal method by default)
 - `--audio-format` and `--video-format` can be used to select codecs. If at least one option is chosen, **the merging engine is changed to FFMPEG**.
-- `--audio-lang` allow to specify audio track language in the output, allowed values are `[chi,eng,jap,kor]`
+- `--audio-lang` allow to specify audio track language in the output, allowed values are `[chi,eng,jpn,kor]`
 
 Maintenance commands and options:
 - `update` retrieves the latest `versions.json` file from the repository and checks if a new version has to be downloaded. It can take several optional parameters as follows :

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Several options are available for most of the commands :
 - `--no-cleanup` disables the suppression of the extracted files after merging
 - `--mkv-engine` specifies the merging program used (either `internal`, `mkvmerge` or `ffmpeg`, using the internal method by default)
 - `--audio-format` and `--video-format` can be used to select codecs. If at least one option is chosen, **the merging engine is changed to FFMPEG**.
+- `--audio-lang` allow to specify audio track language in the output, allowed values are `[chi,eng,jap,kor]`
 
 Maintenance commands and options:
 - `update` retrieves the latest `versions.json` file from the repository and checks if a new version has to be downloaded. It can take several optional parameters as follows :
@@ -106,5 +107,6 @@ Maintenance commands and options:
 - `GICutscenes batchDemux cutscenes/ -o ./output -m -s -e ffmpeg` will extract every USM file into the output directory, merging the files (`-m`) and the subs (`-s`) using FFMPEG (`-e`).
 - `GICutscenes demuxUsm hello.usm -b 00112233 -a 44556677` decrypts the file `hello.usm` with `key1=00112233` and `key2=44556677` and extracts the tracks.
 - `GICutscenes convertHca hello_0.hca` decodes the file and converts it into a WAV file
+- `GICutscenes demuxUsm "[Path to .usm file]" --merge --subs --audio-lang "jpn,eng"` convert single USM file, include subtitles, include only JPN and ENG audio tracks
 
 The video is extracted as an IVF file (which makes codec detection (VP9) easier for mkvmerge). In order to watch it, you can open it into VLC or change the extension to `.m2v`.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -70,9 +70,9 @@ namespace GICutscenes
 
             var audioLangOption = new Option<string>(
                 name: "--audio-lang",
-                description: $"Select audio languages that you wish to include in MKV file.{Environment.NewLine}Example \"eng,jap\")");
+                description: $"Select audio languages that you wish to include in MKV file.{Environment.NewLine}Example \"eng,jpn\")");
             audioLangOption.AddAlias("-al");
-            audioLangOption.SetDefaultValue("chi,eng,jap,kor");
+            audioLangOption.SetDefaultValue("chi,eng,jpn,kor");
 
             var mergeOption = new Option<bool>(
                 name: "--merge",


### PR DESCRIPTION
Currently all audio tracks are being merged into MKV container.
This PR add new option `--audio-lang` to allow user to specify preferable audio track language(s).
Also reducing output file size.