### PR TITLE
Skip empty SRT files

### DIFF
--- a/src/FileTypes/ASS.cs
+++ b/src/FileTypes/ASS.cs
@@ -23,7 +23,7 @@ namespace GICutscenes.FileTypes
             return _srt.ToLower().EndsWith(".ass") && (File.ReadLines(_srt).First() == "[Script Info]"); // Lazy checkup
         }
 
-        public void ParseSrt()
+        public bool ParseSrt()
         {
             string subsLines = File.ReadAllText(_srt); // No worries about the encoding, this is smart enough
             string[] splitLines = subsLines.ReplaceLineEndings().Split(Environment.NewLine);
@@ -66,6 +66,12 @@ namespace GICutscenes.FileTypes
                 _dialogLines.Add(dialogLine);
                 i += 1;
             }
+            if (_dialogLines.Count == 0)
+            {
+                Console.WriteLine($"{_srt} file is empty or incorrect");
+                return false;
+            }
+            return true;
         }
 
         public string ConvertToAss(string outputPath)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -410,15 +410,25 @@ namespace GICutscenes
                                 string res = Array.Find(search, name => ASS.SubsExtensions.Contains(Path.GetExtension(name))) ?? throw new FileNotFoundException(
                                                  $"No valid file could be found for the subs {subName} while the files corresponding to the name is {search.Length}"); ;
                                 Console.WriteLine($"Using subs file {Path.GetFileName(res)}");
+                                bool skipSubs = false;
                                 ASS sub = new(res, lang);
                                 string subFile = search[0];
                                 if (!sub.IsAss())
                                 {
-                                    sub.ParseSrt();
-                                    subFile = sub.ConvertToAss(outputPath);
+                                    if (sub.ParseSrt())
+                                    {
+                                        subFile = sub.ConvertToAss(outputPath);
+                                    }
+                                    else
+                                    {
+                                        skipSubs = true;
+                                    }
                                 }
 
-                                merger.AddSubtitlesTrack(subFile, lang);
+                                if (!skipSubs)
+                                {
+                                    merger.AddSubtitlesTrack(subFile, lang);
+                                }
                                 break;
                             default:
                                 throw new Exception($"Too many results ({search.Length}), please report this case");


### PR DESCRIPTION
There have been a few empty SRT files in the 5.4 update which cause the application to crash with a `NullReferenceException` (e.g. `Cs_Inazuma_LQ1204713_Mizuki_Boy_EN.srt`). This change detects when an SRT file is empty, outputs a warning message to the console, and skips the file without throwing an exception.