### PR TITLE
feat: mimic in-game subs style by default

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -3,6 +3,6 @@
     "MkvMergePath": "",
     "FfmpegPath": "",
     "SubsFolder": "./GenshinData/Subtitle",
-    "SubsStyle": "Style: Default,{fontname},12,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0,0.5,2,10,10,14,1"
+    "SubsStyle": "Style: Default,{fontname},14.5,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100.0,100.0,0.0,0.0,1,0.1,0,2,10,10,17,1"
   }
 }


### PR DESCRIPTION
This defaults the sub style to mimic the in-game sub style.

In-game:
![mpv_zhFcW18Zwo](https://github.com/user-attachments/assets/83f7884c-5f17-45ae-9b28-9d02e22f8d6d)

New default subs style:
![mpv_vwiIuYydyB](https://github.com/user-attachments/assets/eeacbe70-a0b5-4a5e-8495-11900c3308a0)
