### PR TITLE
Fix duplicate video entry in versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -716,8 +716,7 @@
 					"version": "5003",
 					"key": 6626516507698299,
 					"videos": [
-						"Cs_Natlan_AQ50030601_HDD",
-						"CutScene_Natlan_AQ50030601_HDD"
+						"Cs_Natlan_AQ50030601_HDD"
 					]
 				},
 				{

--- a/versions.json
+++ b/versions.json
@@ -508,7 +508,6 @@
 					"version": "4019",
 					"key": 9183447191069533,
 					"videos": [
-						"Cs_Fontaine_AQ401906_DALW",
 						"Cs_Fontaine_AQ40190601_DALW"
 					]
 				},


### PR DESCRIPTION
There is no video named `CutScene_Natlan_AQ50030601_HDD`(It should be `Cs_Natlan_AQ50030601_HDD`, which is already included in the file). This might be added by mistake.